### PR TITLE
add custom sound player and ability to set sound preference

### DIFF
--- a/bin/pomodoro.js
+++ b/bin/pomodoro.js
@@ -3,17 +3,25 @@
 var beep = require('beepbeep' ),
     notifier = require('node-notifier' ),
     program = require('commander' ),
-    progressBar = require('progress' );
+    progressBar = require('progress' ),
+    player = require('play-sound')(opts = {}),
+    fs = require('fs');
 
 var INTERVAL = 1000; // update once per second
 var DEFAULT_DURATION = 25;
 var DEFAULT_BREAK_DURATION = 5;
+
+var prefs = require('user-settings').file('.turnip-settings');
+var settings = {
+    sound: 'full path to notification sound (blank for no sounds)'
+};
 
 program
   .version('turnip ' + require('../package').version)
   .option('-d, --duration <duration>', 'duration in minutes')
   .option('-t, --task <name>', 'task name (default: 25 minutes)')
   .option('-b, --break', 'take a break (default: 5 minutes)')
+  .option('-p, --pref <setting> <value>', 'set preference')
   .parse(process.argv);
 
 // todo handle input errors, default to pomodoro and not help
@@ -25,6 +33,12 @@ if (program.task) {
   var duration = (program.duration && program.duration > 0)
     ? program.duration : DEFAULT_BREAK_DURATION;
     startPomodoro('Break time!', duration);
+} else if(program.pref) {
+  if (program.pref == 'help') {
+    showPrefs();
+  } else {
+    setPref(program.pref, program.args[0]);
+  }
 }
 else{
   program.help();
@@ -45,13 +59,13 @@ function startPomodoro(task, duration) {
       'token1': formatTime(totalTime - elapsedTime)
     });
     if (bar.complete) {
-      beep(2, 100); // todo: find better notification sound
       console.log('\nPomodoro for ' + task + ' completed\n');
       clearInterval(timer);
       notifier.notify({
         'title': 'Pomodoro Complete',
         'message': 'Pomodoro for ' + task + ' completed'
       });
+      audible();
     }
   }, INTERVAL);
 }
@@ -65,4 +79,34 @@ function formatTime(seconds) {
   } else {
     return seconds + 's';
   }
+}
+
+function audible() {
+    var sound = prefs.get('sound') || '/System/Library/Sounds/Submarine.aiff';
+    if (sound !== 'none') {
+        fs.exists(sound, function(exists) {
+            if (exists) {
+                player.play(sound);
+            } else {
+                beep();
+            }
+        });
+    }
+}
+
+function showPrefs() {
+    console.log('available preferences: ');
+    for (name in settings) {
+        console.log(' - ' + name + ': ' + settings[name]);
+    }
+}
+
+function setPref(name, value) {
+    if (settings.hasOwnProperty(name)) {
+        value = value === undefined ? 'none' : value;
+        console.log('set ' + name + ' to ' + value);
+        prefs.set(name, value);
+    } else {
+        console.log('unknown setting: ' + name);
+    }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "turnip",
   "version": "0.0.4",
   "description": "Turnip! Cross-platform CLI Pomodoro Timer",
-  "keywords": ["pomodoro", "cross-platform"],
+  "keywords": [
+    "pomodoro",
+    "cross-platform"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -15,6 +18,8 @@
     "beepbeep": "^1.2.0",
     "commander": "^2.8.1",
     "node-notifier": "^4.2.3",
-    "progress": "^1.1.8"
+    "play-sound": "0.0.7",
+    "progress": "^1.1.8",
+    "user-settings": "^0.1.5"
   }
 }


### PR DESCRIPTION
There was a TODO to find a better sound.  This lets the user pick a sound (or set to none at all):

`turnip -p sound none` (no sound)
- or - 

`turnip -p sound` (same)

`turnip -p sound /System/Library/Sounds/Submarine.aiff`

Preference is stored in ~/.turnip-settings via user-settings package.  If the sound file isn't found, defaults to use beepbeep.